### PR TITLE
Fix: Stop fetching after component is removed from screen

### DIFF
--- a/resources/js/components/FailedJobsPastHour.vue
+++ b/resources/js/components/FailedJobsPastHour.vue
@@ -41,7 +41,11 @@
             }
 
             this.fetchStats();
-            setInterval(this.fetchStats, this.refreshTime * 1000);
+            this.fetchStatsIntervalId = setInterval(this.fetchStats, this.refreshTime * 1000);
+        },
+
+        beforeDestroy() {
+            clearInterval(this.fetchStatsIntervalId);
         },
 
         computed: {

--- a/resources/js/components/JobsPastHour.vue
+++ b/resources/js/components/JobsPastHour.vue
@@ -40,7 +40,11 @@ export default {
         }
 
         this.fetchStats();
-        setInterval(this.fetchStats, this.refreshTime * 1000);
+        this.fetchStatsIntervalId = setInterval(this.fetchStats, this.refreshTime * 1000);
+    },
+
+    beforeDestroy() {
+        clearInterval(this.fetchStatsIntervalId);
     },
 
     computed: {

--- a/resources/js/components/Processes.vue
+++ b/resources/js/components/Processes.vue
@@ -41,7 +41,11 @@
             }
 
             this.fetchStats();
-            setInterval(this.fetchStats, this.refreshTime * 1000);
+            this.fetchStatsIntervalId = setInterval(this.fetchStats, this.refreshTime * 1000);
+        },
+
+        beforeDestroy() {
+            clearInterval(this.fetchStatsIntervalId);
         },
 
         computed: {

--- a/resources/js/components/Workload.vue
+++ b/resources/js/components/Workload.vue
@@ -53,7 +53,11 @@
             }
 
             this.fetchStats();
-            setInterval(this.fetchStats, this.refreshTime * 1000);
+            this.fetchStatsIntervalId = setInterval(this.fetchStats, this.refreshTime * 1000);
+        },
+
+        beforeDestroy() {
+            clearInterval(this.fetchStatsIntervalId);
         },
 
         methods: {


### PR DESCRIPTION
This PR will fix a bug that makes background fetching continue after leaving the page containing your components.
When component is removed from screen background fetches are stopped, and when its added back, it will get resumed.


I did not include modified dist files to prevent merge conflicts with other pull requests.
npm run production will have to be done and commited after merge.